### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cfxmarkets/php-cfx-public-models",
+    "name": "cfxmarkets/php-public-models",
     "description": "This package provides all of CFX's public data objects.",
     "keywords": [ "cfx", "api", "brokerage", "exchange", "framework", "data objects" ],
     "license": "MIT",


### PR DESCRIPTION
corrected the name of the package to match php-public-models as in dev-v2 branch. In order to use it `php-brokerage-sdk`, this change should be committed