### PR TITLE
Changed phone number regex to accept numbers only without format

### DIFF
--- a/src/Brokerage/User.php
+++ b/src/Brokerage/User.php
@@ -78,7 +78,8 @@ class User extends \CFX\JsonApi\AbstractResource implements UserInterface {
 
         if ($this->validateRequired('phoneNumber', $val)) {
             if ($this->validateType('phoneNumber', $val, 'string')) {
-                if (!preg_match("/^\(?[0-9]{3}\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$/", $val)) {
+                 
+                if (!preg_match("/^[0-9]{5,}$/", $val)) {
                     $this->setError('phoneNumber', "valid", [
                         "title" => "Invalid Attribute Value for `phoneNumber`",
                         "detail" => "The phone number you've passed is invalid"

--- a/tests/Brokerage/UserTest.php
+++ b/tests/Brokerage/UserTest.php
@@ -20,7 +20,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     {
         $field = 'phoneNumber';
         $this->assertValid($field, [ '8882221111', '8888888888', '1234562323', 1234567890 ]);
-        $this->assertInvalid($field, [ '1234', 'nothing', true, false, new \DateTime(), [], 1234 ]);
+        $this->assertInvalid($field, [ '888.230.0000', '+1 888-555-2233', '1234', 'nothing', true, false, new \DateTime(), [], 1234 ]);
         $this->assertChanged($field, "1112223333", "attributes");
         $this->assertChains($field);
     }

--- a/tests/Brokerage/UserTest.php
+++ b/tests/Brokerage/UserTest.php
@@ -19,9 +19,9 @@ class UserTest extends \PHPUnit\Framework\TestCase
     public function testPhoneNumber()
     {
         $field = 'phoneNumber';
-        $this->assertValid($field, [ '888.222.1111', '8888888888', '123-456-2323', 1234567890 ]);
-        $this->assertInvalid($field, [ '1234', 'nothing', true, false, new \DateTime(), [], 12345 ]);
-        $this->assertChanged($field, "111.222.3333", "attributes");
+        $this->assertValid($field, [ '8882221111', '8888888888', '1234562323', 1234567890 ]);
+        $this->assertInvalid($field, [ '1234', 'nothing', true, false, new \DateTime(), [], 1234 ]);
+        $this->assertChanged($field, "1112223333", "attributes");
         $this->assertChains($field);
     }
 


### PR DESCRIPTION
* Changed phone number regex to accept numbers only without format
* Minimum is 5 digits